### PR TITLE
Fix: use strapiId instead of node.id when rendering list of articles

### DIFF
--- a/src/components/articles.js
+++ b/src/components/articles.js
@@ -12,7 +12,7 @@ const Articles = ({ articles }) => {
         <div>
           {leftArticles.map((article, i) => {
             return (
-              <Card article={article} key={`article__${article.node.id}`} />
+              <Card article={article} key={`article__${article.node.strapiId}`} />
             )
           })}
         </div>
@@ -20,7 +20,7 @@ const Articles = ({ articles }) => {
           <div className="uk-child-width-1-2@m uk-grid-match" data-uk-grid>
             {rightArticles.map((article, i) => {
               return (
-                <Card article={article} key={`article__${article.node.id}`} />
+                <Card article={article} key={`article__${article.node.strapiId}`} />
               )
             })}
           </div>


### PR DESCRIPTION
Observed each node doesn't contain an `id` field which led to this error:

<img width="1440" alt="Screenshot 2020-07-09 at 01 35 07" src="https://user-images.githubusercontent.com/10440327/87001013-6dc9b180-c184-11ea-9936-f50b8ffa02fe.png">


<img width="1028" alt="Screenshot 2020-07-09 at 01 31 40" src="https://user-images.githubusercontent.com/10440327/87000983-5be80e80-c184-11ea-9c7e-5afdd47b34ac.png">
